### PR TITLE
Fix Firebase Test Lab bucket permissions

### DIFF
--- a/.github/workflows/firebase-test-lab.yml
+++ b/.github/workflows/firebase-test-lab.yml
@@ -75,6 +75,7 @@ jobs:
             --device "model=Pixel2.arm,version=26"
             --device "model=MediumPhone.arm,version=30"
             --device "model=MediumPhone.arm,version=34"
+            --results-bucket "gs://tcatb-firebase-test-lab"
             --timeout 15m
             --results-history-name "tcatb-android-$BUILD_TYPE"
             --no-auto-google-login


### PR DESCRIPTION
## Summary
- Uses a project-owned GCS bucket (`tcatb-firebase-test-lab`) instead of the auto-created Firebase-managed bucket, which our WIF service account can't write to

## Test plan
- [ ] Merge and re-trigger workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)