### PR TITLE
fix: state-based composable overloads to fix MockK on API 26

### DIFF
--- a/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/MainScreenTabTest.kt
+++ b/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/MainScreenTabTest.kt
@@ -7,14 +7,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.thecityandthebike.setContentWithTheme
 import com.thecityandthebike.ui.viewmodel.BikesListState
-import com.thecityandthebike.ui.viewmodel.BikesListViewModel
 import com.thecityandthebike.ui.viewmodel.LeaderboardState
-import com.thecityandthebike.ui.viewmodel.LeaderboardViewModel
 import com.thecityandthebike.ui.viewmodel.MainState
-import com.thecityandthebike.ui.viewmodel.MainViewModel
-import io.mockk.every
-import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 
@@ -23,28 +17,13 @@ class MainScreenTabTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private fun createMockViewModels(): Triple<MainViewModel, LeaderboardViewModel, BikesListViewModel> {
-        val mainViewModel = mockk<MainViewModel>(relaxed = true)
-        every { mainViewModel.state } returns MutableStateFlow(MainState())
-
-        val leaderboardViewModel = mockk<LeaderboardViewModel>(relaxed = true)
-        every { leaderboardViewModel.state } returns MutableStateFlow(LeaderboardState())
-
-        val bikesListViewModel = mockk<BikesListViewModel>(relaxed = true)
-        every { bikesListViewModel.state } returns MutableStateFlow(BikesListState())
-
-        return Triple(mainViewModel, leaderboardViewModel, bikesListViewModel)
-    }
-
     @Test
     fun mainScreen_showsThreeTabs() {
-        val (mainVM, leaderboardVM, bikesListVM) = createMockViewModels()
-
         composeTestRule.setContentWithTheme {
             MainScreen(
-                viewModel = mainVM,
-                leaderboardViewModel = leaderboardVM,
-                bikesListViewModel = bikesListVM,
+                mainState = MainState(),
+                leaderboardState = LeaderboardState(),
+                bikesListState = BikesListState(),
                 isLoggedIn = false,
                 onLogout = {},
                 onLoginClick = {},
@@ -59,13 +38,11 @@ class MainScreenTabTest {
 
     @Test
     fun mainScreen_loggedIn_showsMeInMenu() {
-        val (mainVM, leaderboardVM, bikesListVM) = createMockViewModels()
-
         composeTestRule.setContentWithTheme {
             MainScreen(
-                viewModel = mainVM,
-                leaderboardViewModel = leaderboardVM,
-                bikesListViewModel = bikesListVM,
+                mainState = MainState(),
+                leaderboardState = LeaderboardState(),
+                bikesListState = BikesListState(),
                 isLoggedIn = true,
                 onLogout = {},
                 onLoginClick = {},
@@ -79,13 +56,11 @@ class MainScreenTabTest {
 
     @Test
     fun mainScreen_loggedOut_doesNotShowMeInMenu() {
-        val (mainVM, leaderboardVM, bikesListVM) = createMockViewModels()
-
         composeTestRule.setContentWithTheme {
             MainScreen(
-                viewModel = mainVM,
-                leaderboardViewModel = leaderboardVM,
-                bikesListViewModel = bikesListVM,
+                mainState = MainState(),
+                leaderboardState = LeaderboardState(),
+                bikesListState = BikesListState(),
                 isLoggedIn = false,
                 onLogout = {},
                 onLoginClick = {},

--- a/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/MeScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/MeScreenTest.kt
@@ -5,11 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import com.thecityandthebike.setContentWithTheme
-import com.thecityandthebike.ui.viewmodel.MeViewModel
 import com.thecityandthebike.ui.viewmodel.UserState
-import io.mockk.every
-import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 
@@ -18,17 +14,11 @@ class MeScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private fun createMockViewModel(): MeViewModel {
-        val viewModel = mockk<MeViewModel>(relaxed = true)
-        every { viewModel.state } returns MutableStateFlow(UserState())
-        return viewModel
-    }
-
     @Test
     fun meScreen_displaysTitle() {
         composeTestRule.setContentWithTheme {
             MeScreen(
-                viewModel = createMockViewModel(),
+                state = UserState(),
                 onBack = {},
                 onImageClick = {}
             )
@@ -41,7 +31,7 @@ class MeScreenTest {
     fun meScreen_backButtonPresent() {
         composeTestRule.setContentWithTheme {
             MeScreen(
-                viewModel = createMockViewModel(),
+                state = UserState(),
                 onBack = {},
                 onImageClick = {}
             )

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
@@ -40,8 +40,12 @@ import com.thecityandthebike.ui.components.LoadingIndicator
 import com.thecityandthebike.ui.components.LoginFAB
 import com.thecityandthebike.ui.components.MenuButton
 import com.thecityandthebike.ui.components.PointsAwardedOverlay
+import com.thecityandthebike.ui.viewmodel.BikesListState
 import com.thecityandthebike.ui.viewmodel.BikesListViewModel
+import com.thecityandthebike.ui.viewmodel.LeaderboardPeriod
+import com.thecityandthebike.ui.viewmodel.LeaderboardState
 import com.thecityandthebike.ui.viewmodel.LeaderboardViewModel
+import com.thecityandthebike.ui.viewmodel.MainState
 import com.thecityandthebike.ui.viewmodel.MainViewModel
 import com.thecityandthebike.util.imageUrlToUri
 import kotlinx.coroutines.launch
@@ -55,9 +59,9 @@ private enum class MainTab(val title: String) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
-    viewModel: MainViewModel,
-    leaderboardViewModel: LeaderboardViewModel,
-    bikesListViewModel: BikesListViewModel,
+    mainState: MainState,
+    leaderboardState: LeaderboardState,
+    bikesListState: BikesListState,
     isLoggedIn: Boolean,
     onLogout: () -> Unit,
     onLoginClick: () -> Unit,
@@ -68,7 +72,16 @@ fun MainScreen(
     onImageClick: ((String) -> Unit)? = null,
     onUserClick: (String) -> Unit = {},
     onBikeClick: (String) -> Unit = {},
-    onShowMe: () -> Unit = {}
+    onShowMe: () -> Unit = {},
+    onRefreshSubmissions: () -> Unit = {},
+    onLoadMoreSubmissions: () -> Unit = {},
+    onRetryUpload: () -> Unit = {},
+    onClearMainError: () -> Unit = {},
+    onClearPointsAwarded: () -> Unit = {},
+    onSelectPeriod: (LeaderboardPeriod) -> Unit = {},
+    onClearLeaderboardError: () -> Unit = {},
+    onLoadMoreBikes: () -> Unit = {},
+    onClearBikesError: () -> Unit = {}
 ) {
     val tabs = MainTab.entries
     val pagerState = rememberPagerState(pageCount = { tabs.size })
@@ -159,25 +172,27 @@ fun MainScreen(
             ) { page ->
                 when (tabs[page]) {
                     MainTab.FEED -> FeedContent(
-                        viewModel = viewModel,
-                        onImageClick = onImageClick
+                        state = mainState,
+                        onImageClick = onImageClick,
+                        onRefresh = onRefreshSubmissions,
+                        onRetryUpload = onRetryUpload,
+                        onLoadMore = onLoadMoreSubmissions,
+                        onClearError = onClearMainError
                     )
                     MainTab.LEADERBOARD -> {
-                        val leaderboardState by leaderboardViewModel.state.collectAsStateWithLifecycle()
                         LeaderboardContent(
                             state = leaderboardState,
-                            onPeriodSelected = { leaderboardViewModel.selectPeriod(it) },
+                            onPeriodSelected = onSelectPeriod,
                             onUserClick = onUserClick,
-                            onClearError = { leaderboardViewModel.clearError() }
+                            onClearError = onClearLeaderboardError
                         )
                     }
                     MainTab.BIKES -> {
-                        val bikesListState by bikesListViewModel.state.collectAsStateWithLifecycle()
                         BikesContent(
                             state = bikesListState,
                             onBikeClick = onBikeClick,
-                            onLoadMore = { bikesListViewModel.loadMoreBikes() },
-                            onClearError = { bikesListViewModel.clearError() }
+                            onLoadMore = onLoadMoreBikes,
+                            onClearError = onClearBikesError
                         )
                     }
                 }
@@ -204,11 +219,10 @@ fun MainScreen(
         }
 
         // Points awarded overlay
-        val mainState by viewModel.state.collectAsStateWithLifecycle()
         mainState.pointsAwarded?.let { breakdown ->
             PointsAwardedOverlay(
                 breakdown = breakdown,
-                onDismiss = { viewModel.clearPointsAwarded() },
+                onDismiss = onClearPointsAwarded,
                 onShowScoreRules = onShowScoreRules
             )
         }
@@ -217,12 +231,63 @@ fun MainScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun FeedContent(
+fun MainScreen(
     viewModel: MainViewModel,
-    onImageClick: ((String) -> Unit)?
+    leaderboardViewModel: LeaderboardViewModel,
+    bikesListViewModel: BikesListViewModel,
+    isLoggedIn: Boolean,
+    onLogout: () -> Unit,
+    onLoginClick: () -> Unit,
+    onScanQrCode: () -> Unit,
+    onShowAbout: () -> Unit = {},
+    onShowScoreRules: () -> Unit = {},
+    onShowPrivacyCopyright: () -> Unit = {},
+    onImageClick: ((String) -> Unit)? = null,
+    onUserClick: (String) -> Unit = {},
+    onBikeClick: (String) -> Unit = {},
+    onShowMe: () -> Unit = {}
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val mainState by viewModel.state.collectAsStateWithLifecycle()
+    val leaderboardState by leaderboardViewModel.state.collectAsStateWithLifecycle()
+    val bikesListState by bikesListViewModel.state.collectAsStateWithLifecycle()
 
+    MainScreen(
+        mainState = mainState,
+        leaderboardState = leaderboardState,
+        bikesListState = bikesListState,
+        isLoggedIn = isLoggedIn,
+        onLogout = onLogout,
+        onLoginClick = onLoginClick,
+        onScanQrCode = onScanQrCode,
+        onShowAbout = onShowAbout,
+        onShowScoreRules = onShowScoreRules,
+        onShowPrivacyCopyright = onShowPrivacyCopyright,
+        onImageClick = onImageClick,
+        onUserClick = onUserClick,
+        onBikeClick = onBikeClick,
+        onShowMe = onShowMe,
+        onRefreshSubmissions = { viewModel.refreshSubmissions() },
+        onLoadMoreSubmissions = { viewModel.loadMoreSubmissions() },
+        onRetryUpload = { viewModel.retryUpload() },
+        onClearMainError = { viewModel.clearError() },
+        onClearPointsAwarded = { viewModel.clearPointsAwarded() },
+        onSelectPeriod = { leaderboardViewModel.selectPeriod(it) },
+        onClearLeaderboardError = { leaderboardViewModel.clearError() },
+        onLoadMoreBikes = { bikesListViewModel.loadMoreBikes() },
+        onClearBikesError = { bikesListViewModel.clearError() }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FeedContent(
+    state: MainState,
+    onImageClick: ((String) -> Unit)?,
+    onRefresh: () -> Unit,
+    onRetryUpload: () -> Unit,
+    onLoadMore: () -> Unit,
+    onClearError: () -> Unit
+) {
     val submissionsWithImages = state.submissions.filter { it.imageUrlThumbnail != null }
     val submissionImageUris = submissionsWithImages.map { submission ->
         imageUrlToUri(submission.imageUrlThumbnail!!)
@@ -240,7 +305,7 @@ private fun FeedContent(
     Box(modifier = Modifier.fillMaxSize()) {
         PullToRefreshBox(
             isRefreshing = state.isRefreshing,
-            onRefresh = { viewModel.refreshSubmissions() },
+            onRefresh = onRefresh,
             modifier = Modifier.fillMaxSize()
         ) {
             ImageGrid(
@@ -258,8 +323,8 @@ private fun FeedContent(
                         }
                     }
                 },
-                onFailedImageClick = { viewModel.retryUpload() },
-                onLoadMore = { viewModel.loadMoreSubmissions() }
+                onFailedImageClick = { onRetryUpload() },
+                onLoadMore = onLoadMore
             )
         }
 
@@ -289,13 +354,13 @@ private fun FeedContent(
                     .padding(16.dp),
                 action = if (state.uploadFailed) {
                     {
-                        TextButton(onClick = { viewModel.retryUpload() }) {
+                        TextButton(onClick = onRetryUpload) {
                             Text("Retry")
                         }
                     }
                 } else null,
                 dismissAction = {
-                    TextButton(onClick = { viewModel.clearError() }) {
+                    TextButton(onClick = onClearError) {
                         Text("Dismiss")
                     }
                 }

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MeScreen.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MeScreen.kt
@@ -16,19 +16,20 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thecityandthebike.ui.viewmodel.DeleteAccountState
 import com.thecityandthebike.ui.viewmodel.MeViewModel
+import com.thecityandthebike.ui.viewmodel.UserState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MeScreen(
-    viewModel: MeViewModel,
+    state: UserState,
     onBack: () -> Unit,
     onImageClick: (String) -> Unit,
+    onLoadMore: () -> Unit = {},
+    onClearError: () -> Unit = {},
     deleteAccountState: DeleteAccountState = DeleteAccountState(),
     onConfirmDeleteAccount: () -> Unit = {},
     onClearDeleteError: () -> Unit = {}
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -48,12 +49,36 @@ fun MeScreen(
             MeContent(
                 state = state,
                 onImageClick = onImageClick,
-                onLoadMore = { viewModel.loadMoreSubmissions() },
-                onClearError = { viewModel.clearError() },
+                onLoadMore = onLoadMore,
+                onClearError = onClearError,
                 deleteAccountState = deleteAccountState,
                 onConfirmDeleteAccount = onConfirmDeleteAccount,
                 onClearDeleteError = onClearDeleteError
             )
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MeScreen(
+    viewModel: MeViewModel,
+    onBack: () -> Unit,
+    onImageClick: (String) -> Unit,
+    deleteAccountState: DeleteAccountState = DeleteAccountState(),
+    onConfirmDeleteAccount: () -> Unit = {},
+    onClearDeleteError: () -> Unit = {}
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    MeScreen(
+        state = state,
+        onBack = onBack,
+        onImageClick = onImageClick,
+        onLoadMore = { viewModel.loadMoreSubmissions() },
+        onClearError = { viewModel.clearError() },
+        deleteAccountState = deleteAccountState,
+        onConfirmDeleteAccount = onConfirmDeleteAccount,
+        onClearDeleteError = onClearDeleteError
+    )
 }


### PR DESCRIPTION
## Summary
- Add state-based overloads of `MeScreen` and `MainScreen` that accept state objects + callbacks instead of ViewModels
- Refactor ViewModel-based overloads to collect state and delegate to the new ones
- Update `MeScreenTest` and `MainScreenTabTest` to use direct state construction, eliminating MockK dependency
- Fixes `MockKException: Missing mocked calls inside every { ... } block` on API 26 (Pixel2.arm) where MockK's bytecode instrumentation can't intercept ViewModel property getters on the older ART runtime

## Test plan
- [x] Local unit tests pass (`testStagingDebugUnitTest`)
- [ ] Firebase Test Lab CI passes on all 3 devices (API 26, 30, 34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)