### PR TITLE
ci: add API 33 and API 35 to Firebase Test Lab

### DIFF
--- a/.github/workflows/firebase-test-lab.yml
+++ b/.github/workflows/firebase-test-lab.yml
@@ -74,7 +74,9 @@ jobs:
             --test "$TEST_APK"
             --device "model=Pixel2.arm,version=26"
             --device "model=MediumPhone.arm,version=30"
+            --device "model=MediumPhone.arm,version=33"
             --device "model=MediumPhone.arm,version=34"
+            --device "model=MediumPhone.arm,version=35"
             --results-bucket "gs://tcatb-firebase-test-lab"
             --timeout 15m
             --results-history-name "tcatb-android-$BUILD_TYPE"


### PR DESCRIPTION
## Summary
- Add `MediumPhone.arm, version=33` (Android 13) — largest active Android version
- Add `MediumPhone.arm, version=35` (Android 15) — latest stable release
- Test matrix now covers: API 26, 30, 33, 34, 35

## Test plan
- [ ] Merge and trigger Firebase Test Lab workflow to confirm all 5 devices pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)