### PR TITLE
Add client-side username validation matching server rules

### DIFF
--- a/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/RegisterScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/com/thecityandthebike/ui/screens/RegisterScreenTest.kt
@@ -20,17 +20,21 @@ class RegisterScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    @Test
-    fun registerScreen_allFormFieldsDisplayed() {
+    private fun renderRegisterScreen(state: AuthState = AuthState()) {
         composeTestRule.setContentWithTheme {
             RegisterScreen(
-                state = AuthState(),
+                state = state,
                 onRegister = { _, _ -> },
                 onNavigateBack = {},
                 onClearError = {},
                 onClearRegistrationSuccess = {}
             )
         }
+    }
+
+    @Test
+    fun registerScreen_allFormFieldsDisplayed() {
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").assertIsDisplayed()
         composeTestRule.onNodeWithText("Password").assertIsDisplayed()
@@ -42,15 +46,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_createAccountButtonDisabledWhenFormEmpty() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNode(hasText("Create Account") and hasClickAction())
             .performScrollTo()
@@ -59,15 +55,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_createAccountButtonEnabledWhenFormValid() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("testuser")
         composeTestRule.onNodeWithText("Password").performTextInput("password123")
@@ -88,15 +76,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_errorTextDisplayed() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(error = "Username already taken"),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen(state = AuthState(error = "Username already taken"))
 
         composeTestRule.onNodeWithText("Username already taken")
             .performScrollTo()
@@ -105,15 +85,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_loadingStateDisablesFields() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(isLoading = true),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen(state = AuthState(isLoading = true))
 
         composeTestRule.onNodeWithText("Username").assertIsNotEnabled()
         composeTestRule.onNodeWithText("Password").assertIsNotEnabled()
@@ -122,15 +94,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_shortPasswordKeepsButtonDisabled() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("testuser")
         composeTestRule.onNodeWithText("Password").performTextInput("short7x")
@@ -150,15 +114,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_shortUsernameKeepsButtonDisabled() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("ab")
         composeTestRule.onNodeWithText("Password").performTextInput("password123")
@@ -178,15 +134,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_shortUsernameShowsValidationError() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("ab")
 
@@ -196,15 +144,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_invalidCharactersShowsValidationError() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("test user")
 
@@ -214,15 +154,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_usernameWithSpecialCharsKeepsButtonDisabled() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Username").performTextInput("user@name")
         composeTestRule.onNodeWithText("Password").performTextInput("password123")
@@ -242,15 +174,7 @@ class RegisterScreenTest {
 
     @Test
     fun registerScreen_passwordMismatchShowsError() {
-        composeTestRule.setContentWithTheme {
-            RegisterScreen(
-                state = AuthState(),
-                onRegister = { _, _ -> },
-                onNavigateBack = {},
-                onClearError = {},
-                onClearRegistrationSuccess = {}
-            )
-        }
+        renderRegisterScreen()
 
         composeTestRule.onNodeWithText("Password").performTextInput("password123")
         composeTestRule.onNodeWithText("Confirm Password").performTextInput("different")

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/RegisterScreen.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/RegisterScreen.kt
@@ -98,7 +98,7 @@ fun RegisterScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    val usernameValidationError = usernameError(username)
+                    val usernameValidationErrorRes = usernameErrorRes(username)
                     OutlinedTextField(
                         value = username,
                         onValueChange = {
@@ -115,8 +115,8 @@ fun RegisterScreen(
                             onNext = { focusManager.moveFocus(FocusDirection.Down) }
                         ),
                         enabled = !state.isLoading,
-                        isError = usernameValidationError != null,
-                        supportingText = usernameValidationError?.let { { Text(it) } }
+                        isError = usernameValidationErrorRes != null,
+                        supportingText = usernameValidationErrorRes?.let { resId -> { Text(stringResource(resId)) } }
                     )
 
                     OutlinedTextField(
@@ -316,11 +316,11 @@ fun RegisterScreen(
 
 private val usernamePattern = Regex("^[a-zA-Z0-9_]+$")
 
-internal fun usernameError(username: String): String? {
+internal fun usernameErrorRes(username: String): Int? {
     if (username.isEmpty()) return null
-    if (username.length < 3) return "Username must be at least 3 characters"
-    if (username.length > 50) return "Username must be 50 characters or fewer"
-    if (!usernamePattern.matches(username)) return "Only letters, numbers, and underscores allowed"
+    if (username.length < 3) return R.string.username_error_too_short
+    if (username.length > 50) return R.string.username_error_too_long
+    if (!usernamePattern.matches(username)) return R.string.username_error_invalid_chars
     return null
 }
 
@@ -332,7 +332,7 @@ private fun isFormValid(
     agreedToLicense: Boolean
 ): Boolean {
     return username.isNotBlank() &&
-            usernameError(username) == null &&
+            usernameErrorRes(username) == null &&
             password.isNotBlank() &&
             password.length >= 8 &&
             password == confirmPassword &&

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,11 @@
     <string name="onboarding_cc_link">Learn more about CC BY-NC 4.0</string>
     <string name="onboarding_cc_link_a11y">Learn more about CC BY-NC 4.0, opens in browser</string>
 
+    <!-- Username validation -->
+    <string name="username_error_too_short">Username must be at least 3 characters</string>
+    <string name="username_error_too_long">Username must be 50 characters or fewer</string>
+    <string name="username_error_invalid_chars">Only letters, numbers, and underscores allowed</string>
+
     <!-- Registration checkboxes -->
     <string name="register_checkbox_read_understood">I\'ve read this and I understand</string>
     <string name="register_checkbox_agree_license">I agree to license my photos under CC BY-NC 4.0</string>

--- a/android/app/src/test/kotlin/com/thecityandthebike/ui/screens/UsernameValidationTest.kt
+++ b/android/app/src/test/kotlin/com/thecityandthebike/ui/screens/UsernameValidationTest.kt
@@ -1,5 +1,6 @@
 package com.thecityandthebike.ui.screens
 
+import com.thecityandthebike.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -8,80 +9,80 @@ class UsernameValidationTest {
 
     @Test
     fun `empty username returns null`() {
-        assertNull(usernameError(""))
+        assertNull(usernameErrorRes(""))
     }
 
     @Test
     fun `valid username returns null`() {
-        assertNull(usernameError("testuser"))
-        assertNull(usernameError("abc"))
-        assertNull(usernameError("user_123"))
+        assertNull(usernameErrorRes("testuser"))
+        assertNull(usernameErrorRes("abc"))
+        assertNull(usernameErrorRes("user_123"))
     }
 
     @Test
     fun `username too short returns error`() {
-        assertEquals("Username must be at least 3 characters", usernameError("ab"))
-        assertEquals("Username must be at least 3 characters", usernameError("a"))
+        assertEquals(R.string.username_error_too_short, usernameErrorRes("ab"))
+        assertEquals(R.string.username_error_too_short, usernameErrorRes("a"))
     }
 
     @Test
     fun `username at minimum length is valid`() {
-        assertNull(usernameError("abc"))
+        assertNull(usernameErrorRes("abc"))
     }
 
     @Test
     fun `username too long returns error`() {
         val longName = "a".repeat(51)
-        assertEquals("Username must be 50 characters or fewer", usernameError(longName))
+        assertEquals(R.string.username_error_too_long, usernameErrorRes(longName))
     }
 
     @Test
     fun `username at maximum length is valid`() {
-        assertNull(usernameError("a".repeat(50)))
+        assertNull(usernameErrorRes("a".repeat(50)))
     }
 
     @Test
     fun `username with spaces returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError("test user"))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes("test user"))
     }
 
     @Test
     fun `username with dash returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError("test-user"))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes("test-user"))
     }
 
     @Test
     fun `username with dot returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError("test.user"))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes("test.user"))
     }
 
     @Test
     fun `username with at sign returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError("test@user"))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes("test@user"))
     }
 
     @Test
     fun `username with underscore is valid`() {
-        assertNull(usernameError("test_user"))
+        assertNull(usernameErrorRes("test_user"))
     }
 
     @Test
     fun `username with digits is valid`() {
-        assertNull(usernameError("user123"))
+        assertNull(usernameErrorRes("user123"))
     }
 
     @Test
     fun `username with mixed case is valid`() {
-        assertNull(usernameError("TestUser"))
+        assertNull(usernameErrorRes("TestUser"))
     }
 
     @Test
     fun `username with trailing space returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError("testuser "))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes("testuser "))
     }
 
     @Test
     fun `username with leading space returns error`() {
-        assertEquals("Only letters, numbers, and underscores allowed", usernameError(" testuser"))
+        assertEquals(R.string.username_error_invalid_chars, usernameErrorRes(" testuser"))
     }
 }


### PR DESCRIPTION
## Summary
- Enforce the same username constraints client-side as the server: 3–50 characters, alphanumeric and underscores only (`^[a-zA-Z0-9_]+$`)
- Show inline validation errors on the username field via `supportingText` so users see what's wrong before submitting
- Error messages use string resources for localization consistency

## Test plan
- [x] 15 unit tests covering all validation rules (boundary lengths, invalid chars, trailing/leading spaces)
- [x] 4 new UI tests for inline error display and button-disabled behavior
- [ ] Run instrumented tests on a connected device (`./gradlew connectedAndroidTest`)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)