### PR TITLE
Fix validation error response leaking sensitive input

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -84,7 +84,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
     return JSONResponse(
         status_code=422,
-        content={"detail": exc.errors()},
+        content={"detail": sanitized_errors},
     )
 
 

--- a/api/tests/integration/test_auth.py
+++ b/api/tests/integration/test_auth.py
@@ -213,6 +213,20 @@ class TestRegisterValidationLogging:
         log_messages = " ".join(r.message for r in caplog.records)
         assert "a!" in log_messages
 
+    def test_validation_response_redacts_password(self, client):
+        """Validation error response must not leak the raw password value."""
+        response = client.post(
+            "/auth/register",
+            json={
+                "username": "validuser",
+                "password": "x9y8z7",
+            },
+        )
+        assert response.status_code == 422
+        body = response.text
+        assert "x9y8z7" not in body
+        assert "[REDACTED]" in body
+
     def test_validation_error_still_returns_422(self, client, caplog):
         """Validation errors should still return 422 with detail body."""
         with caplog.at_level(logging.WARNING, logger="app.main"):


### PR DESCRIPTION
## Summary
- The validation exception handler sanitized errors for logging (redacting passwords with `[REDACTED]`) but returned raw `exc.errors()` in the HTTP response, leaking sensitive input like passwords to clients
- Changed the response to use the already-sanitized errors instead
- Added a test verifying passwords are redacted in validation error responses

Closes #262

## Test plan
- [x] New test `test_validation_response_redacts_password` verifies password is not in response body and `[REDACTED]` appears
- [x] All 452 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)