### PR TITLE
Add offline-first submission upload queue

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-feature android:name="android.hardware.camera" android:required="true" />
 
     <application

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/components/ImageGrid.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/components/ImageGrid.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -48,6 +49,7 @@ fun ImageGrid(
     uploadingUris: Set<Uri> = emptySet(),
     failedUris: Set<Uri> = emptySet(),
     flaggedUris: Set<Uri> = emptySet(),
+    queuedUris: Set<Uri> = emptySet(),
     onImageClick: ((Int) -> Unit)? = null,
     onFailedImageClick: ((Uri) -> Unit)? = null,
     onLoadMore: (() -> Unit)? = null
@@ -80,6 +82,7 @@ fun ImageGrid(
             val isUploading = uri in uploadingUris
             val isFailed = uri in failedUris
             val isFlagged = uri in flaggedUris
+            val isQueued = uri in queuedUris
             Box(
                 modifier = Modifier
                     .aspectRatio(1f)
@@ -110,6 +113,16 @@ fun ImageGrid(
                         Icon(
                             imageVector = Icons.Default.Warning,
                             contentDescription = "Upload failed",
+                            tint = Color.White,
+                            modifier = Modifier.size(36.dp)
+                        )
+                    }
+                }
+                if (isQueued) {
+                    ImageOverlay(alpha = 0.4f) {
+                        Icon(
+                            imageVector = Icons.Default.Schedule,
+                            contentDescription = "Queued for upload",
                             tint = Color.White,
                             modifier = Modifier.size(36.dp)
                         )

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.thecityandthebike.ui.screens
 
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -313,14 +312,10 @@ private fun FeedContent(
         imageUrlToUri(submission.imageUrlThumbnail!!)
     }
     val pendingUri = state.pendingUploadUri
-    // Build queued upload URIs from the queue (excluding the one currently uploading/failed)
-    val queuedUploadUris = state.queuedUploads.map { upload ->
-        Uri.fromFile(java.io.File(upload.imageFileName))
-    }
     val imageUris = if (pendingUri != null) listOf(pendingUri) + submissionImageUris else submissionImageUris
     val uploadingUris = if (pendingUri != null && !state.uploadFailed) setOf(pendingUri) else emptySet()
     val failedUris = if (pendingUri != null && state.uploadFailed) setOf(pendingUri) else emptySet()
-    val queuedUriSet = queuedUploadUris.toSet() - uploadingUris - failedUris
+    val queuedUriSet = state.queuedUploadUris.toSet() - uploadingUris - failedUris
     val flaggedUris = submissionsWithImages
         .mapIndexedNotNull { index, submission ->
             if ((submission.flagCount ?: 0) > 0) submissionImageUris[index] else null

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/screens/MainScreen.kt
@@ -1,10 +1,13 @@
 package com.thecityandthebike.ui.screens
 
+import android.net.Uri
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.navigationBars
@@ -19,6 +22,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -165,6 +169,22 @@ fun MainScreen(
                 }
             }
 
+            // Offline banner
+            if (mainState.isOffline) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.errorContainer)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Text(
+                        text = "You're offline \u2014 uploads will resume when connected",
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
             // Swipeable content
             HorizontalPager(
                 state = pagerState,
@@ -293,9 +313,14 @@ private fun FeedContent(
         imageUrlToUri(submission.imageUrlThumbnail!!)
     }
     val pendingUri = state.pendingUploadUri
+    // Build queued upload URIs from the queue (excluding the one currently uploading/failed)
+    val queuedUploadUris = state.queuedUploads.map { upload ->
+        Uri.fromFile(java.io.File(upload.imageFileName))
+    }
     val imageUris = if (pendingUri != null) listOf(pendingUri) + submissionImageUris else submissionImageUris
     val uploadingUris = if (pendingUri != null && !state.uploadFailed) setOf(pendingUri) else emptySet()
     val failedUris = if (pendingUri != null && state.uploadFailed) setOf(pendingUri) else emptySet()
+    val queuedUriSet = queuedUploadUris.toSet() - uploadingUris - failedUris
     val flaggedUris = submissionsWithImages
         .mapIndexedNotNull { index, submission ->
             if ((submission.flagCount ?: 0) > 0) submissionImageUris[index] else null
@@ -313,6 +338,7 @@ private fun FeedContent(
                 uploadingUris = uploadingUris,
                 failedUris = failedUris,
                 flaggedUris = flaggedUris,
+                queuedUris = queuedUriSet,
                 modifier = Modifier.fillMaxSize(),
                 onImageClick = onImageClick?.let { callback ->
                     { index ->

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/viewmodel/MainViewModel.kt
@@ -7,7 +7,6 @@ import com.thecityandthebike.data.model.ApiResult
 import com.thecityandthebike.data.model.dto.ScoringBreakdown
 import com.thecityandthebike.data.model.dto.SubmissionResponse
 import com.thecityandthebike.data.repository.SubmissionRepository
-import com.thecityandthebike.upload.PendingUpload
 import com.thecityandthebike.upload.UploadManager
 import com.thecityandthebike.upload.UploadState
 import com.thecityandthebike.util.ConnectivityMonitor
@@ -31,7 +30,7 @@ data class MainState(
     val pointsAwarded: List<ScoringBreakdown>? = null,
     val pendingUploadCount: Int = 0,
     val isOffline: Boolean = false,
-    val queuedUploads: List<PendingUpload> = emptyList()
+    val queuedUploadUris: List<Uri> = emptyList()
 )
 
 @HiltViewModel
@@ -88,7 +87,7 @@ class MainViewModel @Inject constructor(
             uploadManager.pendingUploads.collect { uploads ->
                 _state.value = _state.value.copy(
                     pendingUploadCount = uploads.size,
-                    queuedUploads = uploads
+                    queuedUploadUris = uploads.map { Uri.fromFile(uploadManager.getImageFile(it.id)) }
                 )
             }
         }

--- a/android/app/src/main/kotlin/com/thecityandthebike/ui/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/ui/viewmodel/MainViewModel.kt
@@ -7,8 +7,10 @@ import com.thecityandthebike.data.model.ApiResult
 import com.thecityandthebike.data.model.dto.ScoringBreakdown
 import com.thecityandthebike.data.model.dto.SubmissionResponse
 import com.thecityandthebike.data.repository.SubmissionRepository
+import com.thecityandthebike.upload.PendingUpload
 import com.thecityandthebike.upload.UploadManager
 import com.thecityandthebike.upload.UploadState
+import com.thecityandthebike.util.ConnectivityMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,13 +28,17 @@ data class MainState(
     val nextCursor: String? = null,
     val pendingUploadUri: Uri? = null,
     val uploadFailed: Boolean = false,
-    val pointsAwarded: List<ScoringBreakdown>? = null
+    val pointsAwarded: List<ScoringBreakdown>? = null,
+    val pendingUploadCount: Int = 0,
+    val isOffline: Boolean = false,
+    val queuedUploads: List<PendingUpload> = emptyList()
 )
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val submissionRepository: SubmissionRepository,
-    private val uploadManager: UploadManager
+    private val uploadManager: UploadManager,
+    private val connectivityMonitor: ConnectivityMonitor
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MainState())
@@ -41,6 +47,8 @@ class MainViewModel @Inject constructor(
     init {
         loadSubmissions()
         observeUploadState()
+        observePendingUploads()
+        observeConnectivity()
     }
 
     private fun observeUploadState() {
@@ -71,6 +79,25 @@ class MainViewModel @Inject constructor(
                     }
                     else -> {}
                 }
+            }
+        }
+    }
+
+    private fun observePendingUploads() {
+        viewModelScope.launch {
+            uploadManager.pendingUploads.collect { uploads ->
+                _state.value = _state.value.copy(
+                    pendingUploadCount = uploads.size,
+                    queuedUploads = uploads
+                )
+            }
+        }
+    }
+
+    private fun observeConnectivity() {
+        viewModelScope.launch {
+            connectivityMonitor.isOnline.collect { online ->
+                _state.value = _state.value.copy(isOffline = !online)
             }
         }
     }

--- a/android/app/src/main/kotlin/com/thecityandthebike/upload/PendingUpload.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/upload/PendingUpload.kt
@@ -1,0 +1,21 @@
+package com.thecityandthebike.upload
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PendingUpload(
+    val id: String,
+    val imageFileName: String,
+    val bikeQrId: String,
+    val side: String? = null,
+    val capturedDate: String,
+    val createdAt: Long,
+    val status: PendingUploadStatus = PendingUploadStatus.QUEUED
+)
+
+@Serializable
+enum class PendingUploadStatus {
+    QUEUED,
+    UPLOADING,
+    FAILED
+}

--- a/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadManager.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadManager.kt
@@ -2,15 +2,18 @@ package com.thecityandthebike.upload
 
 import android.net.Uri
 import com.thecityandthebike.data.model.ApiResult
+import com.thecityandthebike.data.model.AppError
 import com.thecityandthebike.data.model.dto.ScoringBreakdown
 import com.thecityandthebike.data.repository.SubmissionRepository
 import com.thecityandthebike.di.ApplicationScope
-import com.thecityandthebike.util.ImagePreparer
+import com.thecityandthebike.util.ConnectivityMonitor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
 import java.time.ZoneId
 import javax.inject.Inject
@@ -29,54 +32,112 @@ sealed interface UploadState {
 @Singleton
 class UploadManager @Inject constructor(
     private val submissionRepository: SubmissionRepository,
-    private val imagePreparer: ImagePreparer,
+    private val uploadQueue: UploadQueue,
+    private val connectivityMonitor: ConnectivityMonitor,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
     private val _state = MutableStateFlow<UploadState>(UploadState.Idle)
     val state: StateFlow<UploadState> = _state.asStateFlow()
 
-    private var lastLocalUri: Uri? = null
-    private var lastBikeQrId: String? = null
-    private var lastSide: String? = null
+    val pendingUploads: StateFlow<List<PendingUpload>> = uploadQueue.pendingUploads
+
+    private val processMutex = Mutex()
+
+    init {
+        appScope.launch {
+            var wasOnline = connectivityMonitor.isOnline.value
+            connectivityMonitor.isOnline.collect { online ->
+                if (!wasOnline && online) {
+                    processQueue()
+                }
+                wasOnline = online
+            }
+        }
+    }
 
     fun uploadAndCreateSubmission(localUri: Uri, bikeQrId: String, side: String? = null) {
-        lastLocalUri = localUri
-        lastBikeQrId = bikeQrId
-        lastSide = side
-
         appScope.launch {
             _state.value = UploadState.Uploading(localUri)
 
-            val imageFile = imagePreparer.prepareImageFile(localUri)
+            val capturedDate = LocalDate.now(ZoneId.of("America/Los_Angeles")).toString()
+            val pending = uploadQueue.enqueue(localUri, bikeQrId, side, capturedDate)
 
-            if (imageFile == null) {
+            if (pending == null) {
                 _state.value = UploadState.Error("Could not read image file", localUri)
                 return@launch
             }
 
-            try {
-                val capturedDate = LocalDate.now(ZoneId.of("America/Los_Angeles")).toString()
-                when (val result = submissionRepository.createSubmission(imageFile, bikeQrId, capturedDate, side = side)) {
+            processQueue()
+        }
+    }
+
+    fun retryUpload() {
+        appScope.launch {
+            // Reset any FAILED items back to QUEUED
+            val uploads = uploadQueue.getAll()
+            for (upload in uploads) {
+                if (upload.status == PendingUploadStatus.FAILED) {
+                    uploadQueue.updateStatus(upload.id, PendingUploadStatus.QUEUED)
+                }
+            }
+            processQueue()
+        }
+    }
+
+    suspend fun processQueue() {
+        if (!processMutex.tryLock()) return
+        try {
+            while (true) {
+                val next = uploadQueue.getAll()
+                    .firstOrNull { it.status == PendingUploadStatus.QUEUED }
+                    ?: break
+
+                if (!connectivityMonitor.isOnline.value) break
+
+                uploadQueue.updateStatus(next.id, PendingUploadStatus.UPLOADING)
+                val imageFile = uploadQueue.getImageFile(next.id)
+                val localUri = Uri.fromFile(imageFile)
+                _state.value = UploadState.Uploading(localUri)
+
+                when (val result = submissionRepository.createSubmission(
+                    imageFile, next.bikeQrId, next.capturedDate, side = next.side
+                )) {
                     is ApiResult.Success -> {
+                        uploadQueue.remove(next.id)
                         _state.value = UploadState.Success(
                             pointsAwarded = result.data.pointsAwarded ?: 0,
                             pointsBreakdown = result.data.pointsBreakdown ?: emptyList()
                         )
                     }
                     is ApiResult.Error -> {
-                        _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                        when (result.error) {
+                            is AppError.Network -> {
+                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
+                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                                return
+                            }
+                            is AppError.Server -> {
+                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
+                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                                return
+                            }
+                            is AppError.RateLimit -> {
+                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
+                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                                return
+                            }
+                            else -> {
+                                // Non-retryable (Auth, Validation, Unknown) — remove from queue
+                                uploadQueue.remove(next.id)
+                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                            }
+                        }
                     }
                 }
-            } finally {
-                imageFile.delete()
             }
+        } finally {
+            processMutex.unlock()
         }
-    }
-
-    fun retryUpload() {
-        val uri = lastLocalUri ?: return
-        val bikeQrId = lastBikeQrId ?: return
-        uploadAndCreateSubmission(uri, bikeQrId, lastSide)
     }
 
     fun clearSuccess() {
@@ -87,8 +148,5 @@ class UploadManager @Inject constructor(
 
     fun clearError() {
         _state.value = UploadState.Idle
-        lastLocalUri = null
-        lastBikeQrId = null
-        lastSide = null
     }
 }

--- a/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadManager.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadManager.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
 import java.time.ZoneId
 import javax.inject.Inject
@@ -40,6 +39,8 @@ class UploadManager @Inject constructor(
     val state: StateFlow<UploadState> = _state.asStateFlow()
 
     val pendingUploads: StateFlow<List<PendingUpload>> = uploadQueue.pendingUploads
+
+    fun getImageFile(id: String) = uploadQueue.getImageFile(id)
 
     private val processMutex = Mutex()
 
@@ -84,7 +85,7 @@ class UploadManager @Inject constructor(
         }
     }
 
-    suspend fun processQueue() {
+    private suspend fun processQueue() {
         if (!processMutex.tryLock()) return
         try {
             while (true) {
@@ -110,28 +111,16 @@ class UploadManager @Inject constructor(
                         )
                     }
                     is ApiResult.Error -> {
-                        when (result.error) {
-                            is AppError.Network -> {
-                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
-                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
-                                return
-                            }
-                            is AppError.Server -> {
-                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
-                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
-                                return
-                            }
-                            is AppError.RateLimit -> {
-                                uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
-                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
-                                return
-                            }
-                            else -> {
-                                // Non-retryable (Auth, Validation, Unknown) — remove from queue
-                                uploadQueue.remove(next.id)
-                                _state.value = UploadState.Error(result.error.displayMessage, localUri)
-                            }
+                        val isRetryable = result.error is AppError.Network ||
+                            result.error is AppError.Server ||
+                            result.error is AppError.RateLimit
+                        if (isRetryable) {
+                            uploadQueue.updateStatus(next.id, PendingUploadStatus.FAILED)
+                        } else {
+                            uploadQueue.remove(next.id)
                         }
+                        _state.value = UploadState.Error(result.error.displayMessage, localUri)
+                        if (isRetryable) return
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadQueue.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadQueue.kt
@@ -1,0 +1,125 @@
+package com.thecityandthebike.upload
+
+import android.content.Context
+import android.net.Uri
+import com.thecityandthebike.util.ImagePreparer
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UploadQueue @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val imagePreparer: ImagePreparer
+) {
+    private val queueDir = File(context.filesDir, "pending_uploads")
+    private val mutex = Mutex()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _pendingUploads = MutableStateFlow<List<PendingUpload>>(emptyList())
+    val pendingUploads: StateFlow<List<PendingUpload>> = _pendingUploads.asStateFlow()
+
+    init {
+        queueDir.mkdirs()
+        val uploads = scanDirectory()
+        // Reset any UPLOADING items to QUEUED (app was killed mid-upload)
+        val resetUploads = uploads.map { upload ->
+            if (upload.status == PendingUploadStatus.UPLOADING) {
+                val updated = upload.copy(status = PendingUploadStatus.QUEUED)
+                writeMetadata(upload.id, updated)
+                updated
+            } else {
+                upload
+            }
+        }
+        _pendingUploads.value = resetUploads.sortedBy { it.createdAt }
+    }
+
+    suspend fun enqueue(
+        uri: Uri,
+        bikeQrId: String,
+        side: String?,
+        capturedDate: String
+    ): PendingUpload? = mutex.withLock {
+        val id = UUID.randomUUID().toString()
+        val uploadDir = File(queueDir, id)
+        uploadDir.mkdirs()
+
+        val imageFile = imagePreparer.prepareImageFile(uri) ?: run {
+            uploadDir.deleteRecursively()
+            return@withLock null
+        }
+
+        val destFile = File(uploadDir, "image.jpg")
+        imageFile.copyTo(destFile, overwrite = true)
+        imageFile.delete()
+
+        val upload = PendingUpload(
+            id = id,
+            imageFileName = "image.jpg",
+            bikeQrId = bikeQrId,
+            side = side,
+            capturedDate = capturedDate,
+            createdAt = System.currentTimeMillis()
+        )
+        writeMetadata(id, upload)
+        _pendingUploads.value = (_pendingUploads.value + upload).sortedBy { it.createdAt }
+        upload
+    }
+
+    fun getImageFile(id: String): File {
+        return File(File(queueDir, id), "image.jpg")
+    }
+
+    suspend fun getAll(): List<PendingUpload> = mutex.withLock {
+        _pendingUploads.value
+    }
+
+    suspend fun remove(id: String) = mutex.withLock {
+        File(queueDir, id).deleteRecursively()
+        _pendingUploads.value = _pendingUploads.value.filter { it.id != id }
+    }
+
+    suspend fun updateStatus(id: String, status: PendingUploadStatus) = mutex.withLock {
+        val uploads = _pendingUploads.value.map { upload ->
+            if (upload.id == id) {
+                val updated = upload.copy(status = status)
+                writeMetadata(id, updated)
+                updated
+            } else {
+                upload
+            }
+        }
+        _pendingUploads.value = uploads
+    }
+
+    private fun scanDirectory(): List<PendingUpload> {
+        val dirs = queueDir.listFiles()?.filter { it.isDirectory } ?: return emptyList()
+        return dirs.mapNotNull { dir ->
+            val metadataFile = File(dir, "metadata.json")
+            if (!metadataFile.exists()) {
+                dir.deleteRecursively()
+                return@mapNotNull null
+            }
+            try {
+                json.decodeFromString<PendingUpload>(metadataFile.readText())
+            } catch (_: Exception) {
+                dir.deleteRecursively()
+                null
+            }
+        }
+    }
+
+    private fun writeMetadata(id: String, upload: PendingUpload) {
+        val metadataFile = File(File(queueDir, id), "metadata.json")
+        metadataFile.writeText(json.encodeToString(PendingUpload.serializer(), upload))
+    }
+}

--- a/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadQueue.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/upload/UploadQueue.kt
@@ -48,35 +48,34 @@ class UploadQueue @Inject constructor(
         bikeQrId: String,
         side: String?,
         capturedDate: String
-    ): PendingUpload? = mutex.withLock {
-        val id = UUID.randomUUID().toString()
-        val uploadDir = File(queueDir, id)
-        uploadDir.mkdirs()
+    ): PendingUpload? {
+        val imageFile = imagePreparer.prepareImageFile(uri) ?: return null
 
-        val imageFile = imagePreparer.prepareImageFile(uri) ?: run {
-            uploadDir.deleteRecursively()
-            return@withLock null
+        return mutex.withLock {
+            val id = UUID.randomUUID().toString()
+            val uploadDir = File(queueDir, id)
+            uploadDir.mkdirs()
+
+            val destFile = File(uploadDir, IMAGE_FILENAME)
+            imageFile.copyTo(destFile, overwrite = true)
+            imageFile.delete()
+
+            val upload = PendingUpload(
+                id = id,
+                imageFileName = IMAGE_FILENAME,
+                bikeQrId = bikeQrId,
+                side = side,
+                capturedDate = capturedDate,
+                createdAt = System.currentTimeMillis()
+            )
+            writeMetadata(id, upload)
+            _pendingUploads.value = (_pendingUploads.value + upload).sortedBy { it.createdAt }
+            upload
         }
-
-        val destFile = File(uploadDir, "image.jpg")
-        imageFile.copyTo(destFile, overwrite = true)
-        imageFile.delete()
-
-        val upload = PendingUpload(
-            id = id,
-            imageFileName = "image.jpg",
-            bikeQrId = bikeQrId,
-            side = side,
-            capturedDate = capturedDate,
-            createdAt = System.currentTimeMillis()
-        )
-        writeMetadata(id, upload)
-        _pendingUploads.value = (_pendingUploads.value + upload).sortedBy { it.createdAt }
-        upload
     }
 
     fun getImageFile(id: String): File {
-        return File(File(queueDir, id), "image.jpg")
+        return File(File(queueDir, id), IMAGE_FILENAME)
     }
 
     suspend fun getAll(): List<PendingUpload> = mutex.withLock {
@@ -116,6 +115,10 @@ class UploadQueue @Inject constructor(
                 null
             }
         }
+    }
+
+    companion object {
+        private const val IMAGE_FILENAME = "image.jpg"
     }
 
     private fun writeMetadata(id: String, upload: PendingUpload) {

--- a/android/app/src/main/kotlin/com/thecityandthebike/util/ConnectivityMonitor.kt
+++ b/android/app/src/main/kotlin/com/thecityandthebike/util/ConnectivityMonitor.kt
@@ -1,0 +1,46 @@
+package com.thecityandthebike.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectivityMonitor @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val _isOnline = MutableStateFlow(checkCurrentConnectivity())
+    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    init {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        connectivityManager.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                _isOnline.value = true
+            }
+
+            override fun onLost(network: Network) {
+                _isOnline.value = checkCurrentConnectivity()
+            }
+        })
+    }
+
+    private fun checkCurrentConnectivity(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/android/app/src/test/kotlin/com/thecityandthebike/upload/UploadQueueTest.kt
+++ b/android/app/src/test/kotlin/com/thecityandthebike/upload/UploadQueueTest.kt
@@ -1,0 +1,216 @@
+package com.thecityandthebike.upload
+
+import android.net.Uri
+import com.thecityandthebike.util.ImagePreparer
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class UploadQueueTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var imagePreparer: ImagePreparer
+    private lateinit var filesDir: File
+
+    @Before
+    fun setup() {
+        imagePreparer = mockk()
+        filesDir = tempFolder.root
+    }
+
+    private fun createQueue(): UploadQueue {
+        val context = mockk<android.content.Context> {
+            io.mockk.every { filesDir } returns this@UploadQueueTest.filesDir
+        }
+        return UploadQueue(context, imagePreparer)
+    }
+
+    @Test
+    fun `enqueue creates files and returns pending upload`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", "left", "2026-03-06")
+
+        assertNotNull(upload)
+        assertEquals("bike1", upload!!.bikeQrId)
+        assertEquals("left", upload.side)
+        assertEquals("2026-03-06", upload.capturedDate)
+        assertEquals(PendingUploadStatus.QUEUED, upload.status)
+
+        // Verify files exist
+        val imageFile = queue.getImageFile(upload.id)
+        assertTrue(imageFile.exists())
+        assertArrayEquals(byteArrayOf(1, 2, 3), imageFile.readBytes())
+    }
+
+    @Test
+    fun `enqueue returns null when image preparation fails`() = runTest {
+        val uri = mockk<Uri>()
+        coEvery { imagePreparer.prepareImageFile(uri) } returns null
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")
+
+        assertNull(upload)
+        assertEquals(0, queue.pendingUploads.value.size)
+    }
+
+    @Test
+    fun `getAll returns enqueued items`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        queue.enqueue(uri, "bike1", null, "2026-03-06")
+
+        // prepareImageFile returns a new file each time since the old was deleted
+        val sourceFile2 = tempFolder.newFile("source2.jpg")
+        sourceFile2.writeBytes(byteArrayOf(4, 5, 6))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile2
+
+        queue.enqueue(uri, "bike2", "right", "2026-03-07")
+
+        val all = queue.getAll()
+        assertEquals(2, all.size)
+        assertEquals("bike1", all[0].bikeQrId)
+        assertEquals("bike2", all[1].bikeQrId)
+    }
+
+    @Test
+    fun `remove cleans up files and state`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")!!
+
+        queue.remove(upload.id)
+
+        assertEquals(0, queue.getAll().size)
+        assertFalse(queue.getImageFile(upload.id).exists())
+    }
+
+    @Test
+    fun `updateStatus persists new status`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")!!
+
+        queue.updateStatus(upload.id, PendingUploadStatus.UPLOADING)
+
+        val updated = queue.getAll().first()
+        assertEquals(PendingUploadStatus.UPLOADING, updated.status)
+
+        // Verify persistence by creating a new queue from the same directory
+        val queue2 = createQueue()
+        val reloaded = queue2.getAll().first()
+        // Should be reset to QUEUED on init (app killed mid-upload recovery)
+        assertEquals(PendingUploadStatus.QUEUED, reloaded.status)
+    }
+
+    @Test
+    fun `init resets UPLOADING items to QUEUED`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")!!
+        queue.updateStatus(upload.id, PendingUploadStatus.UPLOADING)
+        assertEquals(PendingUploadStatus.UPLOADING, queue.getAll().first().status)
+
+        // Create a fresh queue from the same directory — simulates app restart
+        val queue2 = createQueue()
+        val recovered = queue2.getAll().first()
+        assertEquals(PendingUploadStatus.QUEUED, recovered.status)
+        assertEquals(upload.id, recovered.id)
+    }
+
+    @Test
+    fun `init leaves FAILED items as FAILED`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")!!
+        queue.updateStatus(upload.id, PendingUploadStatus.FAILED)
+
+        val queue2 = createQueue()
+        val recovered = queue2.getAll().first()
+        assertEquals(PendingUploadStatus.FAILED, recovered.status)
+    }
+
+    @Test
+    fun `init cleans up directories with corrupt metadata`() = runTest {
+        // Create a valid entry first
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        queue.enqueue(uri, "bike1", null, "2026-03-06")
+
+        // Manually create a corrupt entry in the queue directory
+        val corruptDir = File(File(filesDir, "pending_uploads"), "corrupt-id")
+        corruptDir.mkdirs()
+        File(corruptDir, "metadata.json").writeText("not valid json{{{")
+        File(corruptDir, "image.jpg").writeBytes(byteArrayOf(7, 8, 9))
+
+        // Also create a directory with no metadata at all
+        val orphanDir = File(File(filesDir, "pending_uploads"), "orphan-id")
+        orphanDir.mkdirs()
+        File(orphanDir, "image.jpg").writeBytes(byteArrayOf(4, 5, 6))
+
+        // Create a new queue — simulates app restart
+        val queue2 = createQueue()
+
+        // Should only have the valid entry
+        assertEquals(1, queue2.getAll().size)
+        assertEquals("bike1", queue2.getAll().first().bikeQrId)
+        // Corrupt and orphan dirs should be cleaned up
+        assertFalse(corruptDir.exists())
+        assertFalse(orphanDir.exists())
+    }
+
+    @Test
+    fun `pendingUploads StateFlow reflects changes`() = runTest {
+        val uri = mockk<Uri>()
+        val sourceFile = tempFolder.newFile("source.jpg")
+        sourceFile.writeBytes(byteArrayOf(1, 2, 3))
+        coEvery { imagePreparer.prepareImageFile(uri) } returns sourceFile
+
+        val queue = createQueue()
+        assertEquals(0, queue.pendingUploads.value.size)
+
+        val upload = queue.enqueue(uri, "bike1", null, "2026-03-06")!!
+        assertEquals(1, queue.pendingUploads.value.size)
+
+        queue.remove(upload.id)
+        assertEquals(0, queue.pendingUploads.value.size)
+    }
+}

--- a/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/MainViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/MainViewModelTest.kt
@@ -7,7 +7,10 @@ import com.thecityandthebike.data.model.dto.CursorPaginatedSubmissions
 import com.thecityandthebike.data.model.dto.SubmissionResponse
 import com.thecityandthebike.data.repository.SubmissionRepository
 import com.thecityandthebike.ui.viewmodel.MainViewModel
+import com.thecityandthebike.upload.PendingUpload
+import com.thecityandthebike.upload.PendingUploadStatus
 import com.thecityandthebike.upload.UploadManager
+import com.thecityandthebike.util.ConnectivityMonitor
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -30,7 +33,10 @@ class MainViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var submissionRepository: SubmissionRepository
     private lateinit var uploadManager: UploadManager
+    private lateinit var connectivityMonitor: ConnectivityMonitor
     private val uploadStateFlow = MutableStateFlow<UploadState>(UploadState.Idle)
+    private val pendingUploadsFlow = MutableStateFlow<List<PendingUpload>>(emptyList())
+    private val isOnlineFlow = MutableStateFlow(true)
     private lateinit var viewModel: MainViewModel
 
     @Before
@@ -38,8 +44,11 @@ class MainViewModelTest {
         Dispatchers.setMain(testDispatcher)
         submissionRepository = mockk()
         uploadManager = mockk()
+        connectivityMonitor = mockk()
         every { uploadManager.state } returns uploadStateFlow
+        every { uploadManager.pendingUploads } returns pendingUploadsFlow
         every { uploadManager.clearSuccess() } returns Unit
+        every { connectivityMonitor.isOnline } returns isOnlineFlow
     }
 
     @After
@@ -48,7 +57,7 @@ class MainViewModelTest {
     }
 
     private fun createViewModel(): MainViewModel {
-        return MainViewModel(submissionRepository, uploadManager)
+        return MainViewModel(submissionRepository, uploadManager, connectivityMonitor)
     }
 
     @Test
@@ -467,6 +476,59 @@ class MainViewModelTest {
         assertFalse(viewModel.state.value.uploadFailed)
         assertNull(viewModel.state.value.error)
         io.mockk.verify { uploadManager.clearError() }
+    }
+
+    @Test
+    fun `pendingUploads flow updates pendingUploadCount and queuedUploads`() = runTest {
+        val paginated = CursorPaginatedSubmissions(items = emptyList(), nextCursor = null, hasMore = false)
+        coEvery { submissionRepository.getSubmissions(any(), any()) } returns ApiResult.Success(paginated)
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0, viewModel.state.value.pendingUploadCount)
+        assertTrue(viewModel.state.value.queuedUploads.isEmpty())
+
+        val upload = PendingUpload(
+            id = "q1",
+            imageFileName = "image.jpg",
+            bikeQrId = "bike1",
+            capturedDate = "2026-03-06",
+            createdAt = 1000L
+        )
+        pendingUploadsFlow.value = listOf(upload)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, viewModel.state.value.pendingUploadCount)
+        assertEquals(1, viewModel.state.value.queuedUploads.size)
+        assertEquals("q1", viewModel.state.value.queuedUploads[0].id)
+
+        pendingUploadsFlow.value = emptyList()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0, viewModel.state.value.pendingUploadCount)
+        assertTrue(viewModel.state.value.queuedUploads.isEmpty())
+    }
+
+    @Test
+    fun `connectivity flow updates isOffline`() = runTest {
+        val paginated = CursorPaginatedSubmissions(items = emptyList(), nextCursor = null, hasMore = false)
+        coEvery { submissionRepository.getSubmissions(any(), any()) } returns ApiResult.Success(paginated)
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.isOffline)
+
+        isOnlineFlow.value = false
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.isOffline)
+
+        isOnlineFlow.value = true
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.isOffline)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/MainViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/MainViewModelTest.kt
@@ -8,12 +8,13 @@ import com.thecityandthebike.data.model.dto.SubmissionResponse
 import com.thecityandthebike.data.repository.SubmissionRepository
 import com.thecityandthebike.ui.viewmodel.MainViewModel
 import com.thecityandthebike.upload.PendingUpload
-import com.thecityandthebike.upload.PendingUploadStatus
 import com.thecityandthebike.upload.UploadManager
 import com.thecityandthebike.util.ConnectivityMonitor
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +27,7 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
@@ -49,11 +51,14 @@ class MainViewModelTest {
         every { uploadManager.pendingUploads } returns pendingUploadsFlow
         every { uploadManager.clearSuccess() } returns Unit
         every { connectivityMonitor.isOnline } returns isOnlineFlow
+        mockkStatic(Uri::class)
+        every { Uri.fromFile(any()) } returns mockk()
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+        unmockkStatic(Uri::class)
     }
 
     private fun createViewModel(): MainViewModel {
@@ -479,15 +484,19 @@ class MainViewModelTest {
     }
 
     @Test
-    fun `pendingUploads flow updates pendingUploadCount and queuedUploads`() = runTest {
+    fun `pendingUploads flow updates pendingUploadCount and queuedUploadUris`() = runTest {
         val paginated = CursorPaginatedSubmissions(items = emptyList(), nextCursor = null, hasMore = false)
         coEvery { submissionRepository.getSubmissions(any(), any()) } returns ApiResult.Success(paginated)
+
+        val fakeUri = mockk<Uri>()
+        every { Uri.fromFile(any()) } returns fakeUri
+        every { uploadManager.getImageFile("q1") } returns File("/fake/q1/image.jpg")
 
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, viewModel.state.value.pendingUploadCount)
-        assertTrue(viewModel.state.value.queuedUploads.isEmpty())
+        assertTrue(viewModel.state.value.queuedUploadUris.isEmpty())
 
         val upload = PendingUpload(
             id = "q1",
@@ -500,14 +509,14 @@ class MainViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, viewModel.state.value.pendingUploadCount)
-        assertEquals(1, viewModel.state.value.queuedUploads.size)
-        assertEquals("q1", viewModel.state.value.queuedUploads[0].id)
+        assertEquals(1, viewModel.state.value.queuedUploadUris.size)
+        assertEquals(fakeUri, viewModel.state.value.queuedUploadUris[0])
 
         pendingUploadsFlow.value = emptyList()
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, viewModel.state.value.pendingUploadCount)
-        assertTrue(viewModel.state.value.queuedUploads.isEmpty())
+        assertTrue(viewModel.state.value.queuedUploadUris.isEmpty())
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/UploadManagerTest.kt
+++ b/android/app/src/test/kotlin/com/thecityandthebike/viewmodel/UploadManagerTest.kt
@@ -5,17 +5,27 @@ import com.thecityandthebike.data.model.ApiResult
 import com.thecityandthebike.data.model.AppError
 import com.thecityandthebike.data.model.dto.SubmissionResponse
 import com.thecityandthebike.data.repository.SubmissionRepository
+import com.thecityandthebike.upload.PendingUpload
+import com.thecityandthebike.upload.PendingUploadStatus
 import com.thecityandthebike.upload.UploadManager
+import com.thecityandthebike.upload.UploadQueue
 import com.thecityandthebike.upload.UploadState
-import com.thecityandthebike.util.ImagePreparer
+import com.thecityandthebike.util.ConnectivityMonitor
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CompletableDeferred
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -27,170 +37,300 @@ class UploadManagerTest {
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
     private lateinit var submissionRepository: SubmissionRepository
-    private lateinit var imagePreparer: ImagePreparer
+    private lateinit var uploadQueue: UploadQueue
+    private lateinit var connectivityMonitor: ConnectivityMonitor
+    private val isOnlineFlow = MutableStateFlow(true)
+    private val pendingUploadsFlow = MutableStateFlow<List<PendingUpload>>(emptyList())
+    private lateinit var appScope: CoroutineScope
+    // Mutable list to simulate queue state changes across getAll() calls
+    private val queueState = mutableListOf<PendingUpload>()
 
     @Before
     fun setup() {
         submissionRepository = mockk()
-        imagePreparer = mockk()
+        uploadQueue = mockk(relaxUnitFun = true)
+        connectivityMonitor = mockk()
+        appScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        every { connectivityMonitor.isOnline } returns isOnlineFlow
+        every { uploadQueue.pendingUploads } returns pendingUploadsFlow
+        coEvery { uploadQueue.getAll() } answers { queueState.toList() }
+        coEvery { uploadQueue.remove(any()) } answers {
+            queueState.removeAll { it.id == firstArg<String>() }
+        }
+        coEvery { uploadQueue.updateStatus(any(), any()) } answers {
+            val id = firstArg<String>()
+            val status = secondArg<PendingUploadStatus>()
+            val idx = queueState.indexOfFirst { it.id == id }
+            if (idx >= 0) queueState[idx] = queueState[idx].copy(status = status)
+        }
+        mockkStatic(Uri::class)
+        every { Uri.fromFile(any()) } returns mockk()
+    }
+
+    @After
+    fun tearDown() {
+        appScope.cancel()
+        unmockkStatic(Uri::class)
     }
 
     private fun createUploadManager(): UploadManager {
-        return UploadManager(submissionRepository, imagePreparer, testScope)
+        return UploadManager(submissionRepository, uploadQueue, connectivityMonitor, appScope)
     }
 
-    @Test
-    fun `upload success should transition through states`() = testScope.runTest {
-        val uri = mockk<Uri>()
-        val imageFile = mockk<File>(relaxed = true)
-        coEvery { imagePreparer.prepareImageFile(uri) } returns imageFile
+    private fun makePendingUpload(
+        id: String = "test-id",
+        bikeQrId: String = "bike1",
+        status: PendingUploadStatus = PendingUploadStatus.QUEUED
+    ) = PendingUpload(
+        id = id,
+        imageFileName = "image.jpg",
+        bikeQrId = bikeQrId,
+        capturedDate = "2026-03-06",
+        createdAt = 1000L,
+        status = status
+    )
 
-        val submissionResponse = SubmissionResponse(
+    private fun stubSuccessResponse() {
+        val response = SubmissionResponse(
             submissionId = "new-1",
             userId = "user1",
             bikeQrId = "bike1",
             imageUrl = "http://example.com/uploaded.jpg"
         )
-        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns ApiResult.Success(submissionResponse)
+        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns ApiResult.Success(response)
+    }
+
+    @Test
+    fun `upload enqueues and processes queue on success`() = testScope.runTest {
+        val uri = mockk<Uri>()
+        val pending = makePendingUpload()
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } answers {
+            queueState.add(pending)
+            pending
+        }
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        stubSuccessResponse()
 
         val uploadManager = createUploadManager()
-        assertEquals(UploadState.Idle, uploadManager.state.value)
+        testDispatcher.scheduler.advanceUntilIdle()
 
         uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(UploadState.Success(), uploadManager.state.value)
+        assertTrue(uploadManager.state.value is UploadState.Success)
+        coVerify { uploadQueue.remove("test-id") }
     }
 
     @Test
-    fun `upload failure should set error state with localUri`() = testScope.runTest {
+    fun `upload returns error when enqueue fails`() = testScope.runTest {
         val uri = mockk<Uri>()
-        val imageFile = mockk<File>(relaxed = true)
-        coEvery { imagePreparer.prepareImageFile(uri) } returns imageFile
-        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns ApiResult.Error(AppError.Server(500, "Upload failed"))
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } returns null
 
         val uploadManager = createUploadManager()
-        uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val state = uploadManager.state.value
-        assertTrue(state is UploadState.Error)
-        assertEquals("Upload failed", (state as UploadState.Error).message)
-        assertEquals(uri, state.localUri)
-    }
-
-    @Test
-    fun `file conversion failure should set error with localUri and not attempt upload`() = testScope.runTest {
-        val uri = mockk<Uri>()
-        coEvery { imagePreparer.prepareImageFile(uri) } returns null
-
-        val uploadManager = createUploadManager()
         uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = uploadManager.state.value
         assertTrue(state is UploadState.Error)
         assertEquals("Could not read image file", (state as UploadState.Error).message)
-        assertEquals(uri, (state as UploadState.Error).localUri)
+    }
+
+    @Test
+    fun `offline enqueue stores without API call`() = testScope.runTest {
+        isOnlineFlow.value = false
+        val uri = mockk<Uri>()
+        val pending = makePendingUpload()
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } answers {
+            queueState.add(pending)
+            pending
+        }
+
+        val uploadManager = createUploadManager()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        uploadManager.uploadAndCreateSubmission(uri, "bike1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
         coVerify(exactly = 0) { submissionRepository.createSubmission(any<File>(), any(), any(), any()) }
+        assertEquals(1, queueState.size)
     }
 
     @Test
-    fun `clearError should reset to idle`() = testScope.runTest {
-        val uri = mockk<Uri>()
-        coEvery { imagePreparer.prepareImageFile(uri) } returns null
+    fun `coming online triggers queue processing`() = testScope.runTest {
+        isOnlineFlow.value = false
+        val pending = makePendingUpload()
+        queueState.add(pending)
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        stubSuccessResponse()
 
         val uploadManager = createUploadManager()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Simulate reconnect
+        isOnlineFlow.value = true
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(uploadManager.state.value is UploadState.Success)
+        coVerify { uploadQueue.remove("test-id") }
+    }
+
+    @Test
+    fun `network error keeps item in queue as FAILED`() = testScope.runTest {
+        val uri = mockk<Uri>()
+        val pending = makePendingUpload()
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } answers {
+            queueState.add(pending)
+            pending
+        }
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns
+            ApiResult.Error(AppError.Network(java.io.IOException("timeout")))
+
+        val uploadManager = createUploadManager()
+        testDispatcher.scheduler.advanceUntilIdle()
+
         uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(uploadManager.state.value is UploadState.Error)
-
-        uploadManager.clearError()
-        assertEquals(UploadState.Idle, uploadManager.state.value)
+        assertEquals(PendingUploadStatus.FAILED, queueState.first().status)
+        assertEquals(1, queueState.size)
     }
 
     @Test
-    fun `uploading state should carry the local uri`() = testScope.runTest {
+    fun `4xx error removes item from queue`() = testScope.runTest {
         val uri = mockk<Uri>()
-        // Use CompletableDeferred to suspend prepareImageFile so we can observe
-        // the intermediate Uploading state before the upload completes
-        val deferred = CompletableDeferred<File?>()
-        coEvery { imagePreparer.prepareImageFile(uri) } coAnswers { deferred.await() }
+        val pending = makePendingUpload()
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } answers {
+            queueState.add(pending)
+            pending
+        }
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns
+            ApiResult.Error(AppError.Validation("field", "Invalid submission"))
 
         val uploadManager = createUploadManager()
+        testDispatcher.scheduler.advanceUntilIdle()
+
         uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val state = uploadManager.state.value
-        assertTrue(state is UploadState.Uploading)
-        assertEquals(uri, (state as UploadState.Uploading).localUri)
-
-        // Complete the deferred to let the coroutine finish (transitions to Error
-        // since null file means "Could not read image file")
-        deferred.complete(null)
-        testDispatcher.scheduler.advanceUntilIdle()
-
         assertTrue(uploadManager.state.value is UploadState.Error)
+        assertTrue(queueState.isEmpty())
     }
 
     @Test
-    fun `retryUpload re-triggers upload with same params`() = testScope.runTest {
-        val uri = mockk<Uri>()
-        val imageFile = mockk<File>(relaxed = true)
-        coEvery { imagePreparer.prepareImageFile(uri) } returns imageFile
-        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any(), any()) } returns ApiResult.Error(AppError.Server(500, "Upload failed"))
+    fun `retryUpload resets FAILED to QUEUED and processes`() = testScope.runTest {
+        val pending = makePendingUpload(status = PendingUploadStatus.FAILED)
+        queueState.add(pending)
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        stubSuccessResponse()
 
         val uploadManager = createUploadManager()
-        uploadManager.uploadAndCreateSubmission(uri, "bike1", "left")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        uploadManager.retryUpload()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(uploadManager.state.value is UploadState.Success)
+        assertTrue(queueState.isEmpty())
+    }
+
+    @Test
+    fun `server error keeps item in queue as FAILED`() = testScope.runTest {
+        val uri = mockk<Uri>()
+        val pending = makePendingUpload()
+        coEvery { uploadQueue.enqueue(uri, "bike1", null, any()) } answers {
+            queueState.add(pending)
+            pending
+        }
+        every { uploadQueue.getImageFile("test-id") } returns File("/fake/image.jpg")
+        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any()) } returns
+            ApiResult.Error(AppError.Server(500, "Internal Server Error"))
+
+        val uploadManager = createUploadManager()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(uploadManager.state.value is UploadState.Error)
+        assertEquals(PendingUploadStatus.FAILED, queueState.first().status)
+        assertEquals(1, queueState.size)
+    }
 
-        // Now make the retry succeed
-        val submissionResponse = SubmissionResponse(
-            submissionId = "new-1",
-            userId = "user1",
-            bikeQrId = "bike1",
-            imageUrl = "http://example.com/uploaded.jpg"
+    @Test
+    fun `multiple queued items process sequentially`() = testScope.runTest {
+        val pending1 = makePendingUpload(id = "id-1", bikeQrId = "bike1")
+        val pending2 = makePendingUpload(id = "id-2", bikeQrId = "bike2")
+        queueState.addAll(listOf(pending1, pending2))
+        every { uploadQueue.getImageFile("id-1") } returns File("/fake/image1.jpg")
+        every { uploadQueue.getImageFile("id-2") } returns File("/fake/image2.jpg")
+
+        val response1 = SubmissionResponse(
+            submissionId = "s1", userId = "user1", bikeQrId = "bike1",
+            imageUrl = "http://example.com/1.jpg"
         )
-        coEvery { submissionRepository.createSubmission(any<File>(), any(), any(), any(), any()) } returns ApiResult.Success(submissionResponse)
+        val response2 = SubmissionResponse(
+            submissionId = "s2", userId = "user1", bikeQrId = "bike2",
+            imageUrl = "http://example.com/2.jpg"
+        )
+        coEvery { submissionRepository.createSubmission(any<File>(), eq("bike1"), any(), any()) } returns ApiResult.Success(response1)
+        coEvery { submissionRepository.createSubmission(any<File>(), eq("bike2"), any(), any()) } returns ApiResult.Success(response2)
 
-        uploadManager.retryUpload()
+        val uploadManager = createUploadManager()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(UploadState.Success(), uploadManager.state.value)
-        coVerify(exactly = 2) { submissionRepository.createSubmission(any<File>(), "bike1", any(), any(), "left") }
+        // Trigger processing by simulating reconnect
+        isOnlineFlow.value = false
+        testDispatcher.scheduler.advanceUntilIdle()
+        isOnlineFlow.value = true
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Both items should have been removed
+        assertTrue(queueState.isEmpty())
+        coVerify { uploadQueue.remove("id-1") }
+        coVerify { uploadQueue.remove("id-2") }
+        // Final state is the last success
+        assertTrue(uploadManager.state.value is UploadState.Success)
     }
 
     @Test
-    fun `retryUpload with no previous upload is no-op`() = testScope.runTest {
-        val uploadManager = createUploadManager()
+    fun `multiple items stops on retryable error`() = testScope.runTest {
+        val pending1 = makePendingUpload(id = "id-1", bikeQrId = "bike1")
+        val pending2 = makePendingUpload(id = "id-2", bikeQrId = "bike2")
+        queueState.addAll(listOf(pending1, pending2))
+        every { uploadQueue.getImageFile("id-1") } returns File("/fake/image1.jpg")
+        every { uploadQueue.getImageFile("id-2") } returns File("/fake/image2.jpg")
 
-        uploadManager.retryUpload()
+        // First item fails with network error
+        coEvery { submissionRepository.createSubmission(any<File>(), eq("bike1"), any(), any()) } returns
+            ApiResult.Error(AppError.Network(java.io.IOException("timeout")))
+
+        val uploadManager = createUploadManager()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(UploadState.Idle, uploadManager.state.value)
+        isOnlineFlow.value = false
+        testDispatcher.scheduler.advanceUntilIdle()
+        isOnlineFlow.value = true
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // First item should be FAILED, second still QUEUED (processing stopped)
+        assertEquals(2, queueState.size)
+        assertEquals(PendingUploadStatus.FAILED, queueState[0].status)
+        assertEquals(PendingUploadStatus.QUEUED, queueState[1].status)
+        // Second item's API should never have been called
+        coVerify(exactly = 0) { submissionRepository.createSubmission(any<File>(), eq("bike2"), any(), any()) }
     }
 
     @Test
-    fun `clearError clears retry params`() = testScope.runTest {
-        val uri = mockk<Uri>()
-        coEvery { imagePreparer.prepareImageFile(uri) } returns null
-
+    fun `clearError resets state to idle`() = testScope.runTest {
         val uploadManager = createUploadManager()
-        uploadManager.uploadAndCreateSubmission(uri, "bike1")
         testDispatcher.scheduler.advanceUntilIdle()
-
-        assertTrue(uploadManager.state.value is UploadState.Error)
 
         uploadManager.clearError()
-        assertEquals(UploadState.Idle, uploadManager.state.value)
-
-        // Retry should be no-op since params were cleared
-        uploadManager.retryUpload()
-        testDispatcher.scheduler.advanceUntilIdle()
-
         assertEquals(UploadState.Idle, uploadManager.state.value)
     }
 }


### PR DESCRIPTION
## Summary

- Add persistent file-based upload queue so photos captured offline are saved locally and auto-uploaded when connectivity returns
- Add `ConnectivityMonitor` to observe network state and trigger queue processing on reconnect
- Refactor `UploadManager` to enqueue to `UploadQueue` then process FIFO, with retryable vs non-retryable error handling
- Show offline banner and queued-upload clock icons in the feed UI
- Add `ACCESS_NETWORK_STATE` permission

Closes #258

## Test plan

- [x] `UploadQueueTest`: enqueue, getAll, remove, updateStatus, init recovery, corrupt metadata cleanup, StateFlow reactivity (8 tests)
- [x] `UploadManagerTest`: success path, enqueue failure, offline skip, reconnect trigger, network/server error (retryable), validation error (non-retryable), multi-item sequential processing, retry, clearError (11 tests)
- [x] `MainViewModelTest`: pendingUploadCount, queuedUploadUris, isOffline flow updates, plus all pre-existing tests (20 tests)
- [x] Full unit test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)